### PR TITLE
Add OpenCV to avoid error No module named 'cv2'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-diffusers>=0.25.0
 accelerate>=0.25.0
 clip_interrogator>=0.6.0
-sentencepiece
+diffusers>=0.25.0
 lark-parser
 onnxruntime
+opencv-python
+sentencepiece
 spandrel


### PR DESCRIPTION
I just installed the last portable version of ComfyUI and download ComfyUI-Easy-Use using ComfyUI-Manager. When stating ComfyUI, I got the following error triggered by ComfyUI-Easy-Use:

> ModuleNotFoundError: No module named 'cv2'

This PR is to fix the issue by adding the dependency `opencv-python` to `requirements.txt`.

I have also reordered dependencies alphabetically.