### PR TITLE
Fix SyntaxWarning in python 3.12

### DIFF
--- a/py/libs/translate.py
+++ b/py/libs/translate.py
@@ -185,7 +185,7 @@ class ChinesePromptTranslate(Transformer):
 
 
 #定义Prompt文法
-grammar = """
+grammar = r"""
 start: sentence
 sentence: phrase ("," phrase)*
 phrase: emphasis | weight | word | lora | embedding | schedule 

--- a/py/libs/wildcards.py
+++ b/py/libs/wildcards.py
@@ -168,7 +168,7 @@ def process(text, seed=None):
                 replacements_found = True
                 string = string.replace(f"__{match}__", replacement, 1)
             elif '*' in keyword:
-                subpattern = keyword.replace('*', '.*').replace('+','\+')
+                subpattern = keyword.replace('*', '.*').replace('+', r'\+')
                 total_patterns = []
                 found = False
                 for k, v in easy_wildcard_dict.items():

--- a/py/logic.py
+++ b/py/logic.py
@@ -1728,7 +1728,7 @@ class saveText:
             if not os.path.isabs(output_file_path):
                 output_path = os.path.join(self.output_dir, output_path)
             base_output = os.path.basename(output_path)
-            if output_path.endswith("ComfyUI/output") or output_path.endswith("ComfyUI\output"):
+            if output_path.endswith("ComfyUI/output") or output_path.endswith(r"ComfyUI\output"):
                 base_output = ""
 
             # Check output destination


### PR DESCRIPTION
SyntaxWarning log

```
Trying to load custom node /data/ComfyUI/custom_nodes/ComfyUI-Easy-Use
/data/ComfyUI/custom_nodes/ComfyUI-Easy-Use/py/libs/translate.py:188: SyntaxWarning: invalid escape sequence '\s'
  grammar = """
Loading bitsandbytes native library from: /venv/lib/python3.12/site-packages/bitsandbytes/libbitsandbytes_cuda124.so
/data/ComfyUI/custom_nodes/ComfyUI-Easy-Use/py/libs/wildcards.py:171: SyntaxWarning: invalid escape sequence '\+'
  subpattern = keyword.replace('*', '.*').replace('+','\+')
/data/ComfyUI/custom_nodes/ComfyUI-Easy-Use/py/logic.py:1731: SyntaxWarning: invalid escape sequence '\o'
  if output_path.endswith("ComfyUI/output") or output_path.endswith("ComfyUI\output"):
Popen(['git', 'version'], cwd=/data/ComfyUI, stdin=None, shell=False, universal_newlines=False)
Popen(['git', 'version'], cwd=/data/ComfyUI, stdin=None, shell=False, universal_newlines=False)
Popen(['git', 'rev-list', 'HEAD', '--'], cwd=/data/ComfyUI, stdin=None, shell=False, universal_newlines=False)
[ComfyUI-Easy-Use] server: v1.2.6 Loaded
[ComfyUI-Easy-Use] web root: /data/ComfyUI/custom_nodes/ComfyUI-Easy-Use/web_version/v2 Loaded

Import times for custom nodes:
   0.7 seconds: /data/ComfyUI/custom_nodes/ComfyUI-Easy-Use
```

To reproduce the warning log, it is necessary to clear all `__pycache__`.
```
find . -type d -name "__pycache__" -exec rm -r {} +
```
