### PR TITLE
fix: wildcards, improve text encoding handling to prevent Chinese character garb…

### DIFF
--- a/py/libs/wildcards.py
+++ b/py/libs/wildcards.py
@@ -34,11 +34,11 @@ def read_wildcard_dict(wildcard_path):
                 key = os.path.splitext(rel_path)[0].replace('\\', '/').lower()
 
                 try:
-                    with open(file_path, 'r', encoding="ISO-8859-1") as f:
+                    with open(file_path, 'r', encoding="UTF-8", errors="ignore") as f:
                         lines = f.read().splitlines()
                         easy_wildcard_dict[key] = lines
                 except UnicodeDecodeError:
-                    with open(file_path, 'r', encoding="UTF-8", errors="ignore") as f:
+                    with open(file_path, 'r', encoding="ISO-8859-1") as f:
                         lines = f.read().splitlines()
                         easy_wildcard_dict[key] = lines
             elif file.endswith('.yaml'):


### PR DESCRIPTION
ISO-8859-1 encoding can forcibly read any byte (it maps each byte directly to its corresponding character). This means it won't throw any decoding errors, but it will incorrectly interpret UTF-8 encoded Chinese characters as other characters, resulting in garbled text (mojibake). 
ISO-8859-1编码可以强制读取任何字节（它会把每个字节都映射到对应的字符）
这意味着它不会抛出解码错误，但会把UTF-8编码的中文字符错误解释为其他字符
导致中文显示为乱码