### PR TITLE
missing vars

### DIFF
--- a/py/nodes/samplers.py
+++ b/py/nodes/samplers.py
@@ -389,6 +389,12 @@ class samplerFull:
 
                 "loader_settings": {
                     **pipe["loader_settings"],
+                    "steps": steps,
+                    "cfg": cfg,
+                    "sampler_name": sampler_name,
+                    "scheduler": scheduler,
+                    "denoise": denoise,
+                    "add_noise": add_noise,
                     "spent_time": spent_time
                 }
             }


### PR DESCRIPTION
The values from the "normal" samplers was missing in the "loader_settings", it was only present in the presampler https://github.com/yolain/ComfyUI-Easy-Use/blob/50ae13a9935d71c7bb28330cd1f71633526aebfc/py/nodes/preSampling.py#L75-L84
so I just added that to
https://github.com/yolain/ComfyUI-Easy-Use/blob/50ae13a9935d71c7bb28330cd1f71633526aebfc/py/nodes/samplers.py#L390-L392