### PR TITLE
Update logic.py: properly handle overwrite mode

### DIFF
--- a/py/nodes/logic.py
+++ b/py/nodes/logic.py
@@ -1607,8 +1607,10 @@ class saveText:
         if not os.path.exists(output_file_path):
             os.makedirs(output_file_path)
 
-        if not overwrite:
-            pass
+        if overwrite:
+            file_mode = "w"
+        else:
+            file_mode = "a"
 
         log_node_info("Save Text", f"Saving to {filepath}")
 
@@ -1617,13 +1619,13 @@ class saveText:
             for i in text.split("\n"):
                 text_list.append(i.strip())
 
-            with open(filepath, "w", newline="", encoding='utf-8') as csv_file:
+            with open(filepath, file_mode, newline="", encoding='utf-8') as csv_file:
                 csv_writer = csv.writer(csv_file)
                 # Write each line as a separate row in the CSV file
                 for line in text_list:
                     csv_writer.writerow([line])
         else:
-            with open(filepath, "w", newline="", encoding='utf-8') as text_file:
+            with open(filepath, file_mode, newline="", encoding='utf-8') as text_file:
                 for line in text:
                     text_file.write(line)
 


### PR DESCRIPTION
In low-level `OPEN` logic at the system calls level, there are two 'modes' of opening files for writing: `WRITE` which clobbers existing file data and thus does overwrite data, and `APPEND` which does *not* overwrite data and appends data to the end of the file when writing.

In the current code of the module where indicated, using `if not overwrite: pass` does nothing at all, as you hard-code the open mode of `"w"` (which is `WRITE` in my statement above) which is idestructive writing to a file if it already exists, and will overwrite the file even if you say not to.  Instead you should define the file open mode based on analysis of whether you have `overwrite` set to True or not.

This code patch does this by leveraging the `overwrite` boolean to determine the `file_mode` (a new variable used to track this) to set, and then applies that later in all opens in the additional `if/else if/else` blocks to determine which file mode to actually use, thus actually determining whether we're overwriting the file or just appending to an existing file.

(discovered by me and others as a result of helping someone when they indicated there may be a bug in "overwrite" being respected, via the ComfyUI discord channels)