### PR TITLE
Added scale by functions to exact width / height, keeping the aspect ratio same

### DIFF
--- a/locales/en/nodeDefs.json
+++ b/locales/en/nodeDefs.json
@@ -4911,6 +4911,30 @@
     },
     "outputs": {}
   },
+    "easy imageScaleDownByWidth": {
+    "display_name": "Image Scale to Width (Aspect same)",
+    "inputs": {
+      "images": {
+        "name": "images"
+      },
+      "width": {
+        "name": "width"
+      }
+    },
+    "outputs": {}
+  },
+  "easy imageScaleDownByHeight": {
+    "display_name": "Image Scale to Height (Aspect same)",
+    "inputs": {
+      "images": {
+        "name": "images"
+      },
+      "height": {
+        "name": "height"
+      }
+    },
+    "outputs": {}
+  },
   "easy imageScaleDownToSize": {
     "display_name": "Image Scale Down To Size",
     "inputs": {

--- a/locales/zh/nodeDefs.json
+++ b/locales/zh/nodeDefs.json
@@ -5292,6 +5292,38 @@
       }
     }
   },
+    "easy imageScaleDownByWidth": {
+    "display_name": "图像缩小 宽度",
+    "inputs": {
+      "images": {
+        "name": "图像"
+      },
+      "width": {
+        "name": "宽度"
+      }
+    },
+    "outputs": {
+      "0": {
+        "name": "图像"
+      }
+    }
+  },
+    "easy imageScaleDownByHeight": {
+    "display_name": "图像缩小 高度",
+    "inputs": {
+      "images": {
+        "name": "图像"
+      },
+      "height": {
+        "name": "高度"
+      }
+    },
+    "outputs": {
+      "0": {
+        "name": "图像"
+      }
+    }
+  },
   "easy imageScaleDownToSize": {
     "display_name": "图像缩小（按边）",
     "inputs": {

--- a/py/nodes/image.py
+++ b/py/nodes/image.py
@@ -319,6 +319,52 @@ class imageScaleDownBy(imageScaleDown):
     new_height = int(height * scale_by)
     return self.image_scale_down(images, new_width, new_height, "center")
 
+class imageScaleDownByWidth(imageScaleDown):
+  @classmethod
+  def INPUT_TYPES(s):
+    return {
+      "required": {
+        "images": ("IMAGE",),
+        "width": (
+          "INT",
+          {"default": 512, "min": 1, "max": MAX_RESOLUTION, "step": 1},
+        ),
+      }
+    }
+
+  RETURN_TYPES = ("IMAGE",)
+  CATEGORY = "EasyUse/Image"
+  FUNCTION = "image_scale_down_by_width"
+
+  def image_scale_down_by(self, images, new_width):
+    width = images.shape[2]
+    height = images.shape[1]
+    new_height = int((height * new_width)//width)
+    return self.image_scale_down(images, new_width, new_height, "center")
+  
+class imageScaleDownByHeight(imageScaleDown):
+  @classmethod
+  def INPUT_TYPES(s):
+    return {
+      "required": {
+        "images": ("IMAGE",),
+        "height": (
+          "INT",
+          {"default": 512, "min": 1, "max": MAX_RESOLUTION, "step": 1},
+        ),
+      }
+    }
+
+  RETURN_TYPES = ("IMAGE",)
+  CATEGORY = "EasyUse/Image"
+  FUNCTION = "image_scale_down_by_height"
+
+  def image_scale_down_by(self, images, new_height):
+    width = images.shape[2]
+    height = images.shape[1]
+    new_width = int((width * new_height)//height)
+    return self.image_scale_down(images, new_width, new_height, "center")
+
 # 图像缩放尺寸
 class imageScaleDownToSize(imageScaleDownBy):
   @classmethod
@@ -2111,6 +2157,8 @@ NODE_CLASS_MAPPINGS = {
   "easy imagePixelPerfect": imagePixelPerfect,
   "easy imageScaleDown": imageScaleDown,
   "easy imageScaleDownBy": imageScaleDownBy,
+  "easy imageScaleDownByWidth": imageScaleDownByWidth,
+  "easy imageScaleDownByHeight": imageScaleDownByHeight,
   "easy imageScaleDownToSize": imageScaleDownToSize,
   "easy imageScaleToNormPixels": imageScaleToNormPixels,
   "easy imageRatio": imageRatio,
@@ -2149,6 +2197,8 @@ NODE_DISPLAY_NAME_MAPPINGS = {
   "easy imagePixelPerfect": "ImagePixelPerfect",
   "easy imageScaleDown": "Image Scale Down",
   "easy imageScaleDownBy": "Image Scale Down By",
+  "easy imageScaleDownByWidth": "Image Scale to Width (Aspect same)",
+  "easy imageScaleDownByHeight": "Image Scale to Height (Aspect same)",
   "easy imageScaleDownToSize": "Image Scale Down To Size",
   "easy imageScaleToNormPixels": "ImageScaleToNormPixels",
   "easy imageRatio": "ImageRatio",


### PR DESCRIPTION
I am not sure what the rules are regarding merging features. I needed a straightforward way to set width / height of the scaled image, without losing the aspect ratio, so I added the following two functions
- imageScaleDownByWidth
- imageScaleDownByHeight

I am using both. If you find them relevant, kindly accept and merge the PR. Let me know if there should be any changes.
Cheers