### PR TITLE
Add controlnet input to xyplot

### DIFF
--- a/py/libs/xyplot.py
+++ b/py/libs/xyplot.py
@@ -430,7 +430,8 @@ class easyXYPlot():
                         strength = item[2]
                         start_percent = item[3]
                         end_percent = item[4]
-                        positive, negative = easyControlnet().apply(control_net_name, image, positive, negative, strength, start_percent, end_percent, None, 1)
+                        provided_control_net = item[5] if len(item) > 5 else None
+                        positive, negative = easyControlnet().apply(control_net_name, image, positive, negative, strength, start_percent, end_percent, provided_control_net, 1)
             # Flux guidance
             if self.x_type == "Flux Guidance" or self.y_type == "Flux Guidance":
                 positive = plot_image_vars["positive_cond"] if "positive" in plot_image_vars else None

--- a/py/nodes/xyplot.py
+++ b/py/nodes/xyplot.py
@@ -413,6 +413,9 @@ class XYplot_Control_Net:
                 "start_percent": ("FLOAT", {"default": 0.0, "min": 0.00, "max": 1.0, "step": 0.01}),
                 "end_percent": ("FLOAT", {"default": 1.0, "min": 0.00, "max": 1.0, "step": 0.01}),
             },
+            "optional": {
+                "control_net": ("CONTROL_NET",),
+            },
         }
 
     RETURN_TYPES = ("X_Y",)
@@ -421,7 +424,7 @@ class XYplot_Control_Net:
     CATEGORY = "EasyUse/XY Inputs"
 
     def xy_value(self, control_net_name, image, target_parameter, batch_count, first_strength, last_strength, first_start_percent,
-                 last_start_percent, first_end_percent, last_end_percent, strength, start_percent, end_percent):
+                 last_start_percent, first_end_percent, last_end_percent, strength, start_percent, end_percent, control_net=None):
 
         axis, = None,
 
@@ -430,38 +433,38 @@ class XYplot_Control_Net:
         if target_parameter == "strength":
             axis = "advanced: ControlNetStrength"
 
-            values.append([(control_net_name, image, first_strength, start_percent, end_percent)])
+            values.append([(control_net_name, image, first_strength, start_percent, end_percent, control_net)])
             strength_increment = (last_strength - first_strength) / (batch_count - 1) if batch_count > 1 else 0
             for i in range(1, batch_count - 1):
                 values.append([(control_net_name, image, first_strength + i * strength_increment, start_percent,
-                                end_percent)])
+                                end_percent, control_net)])
             if batch_count > 1:
-                values.append([(control_net_name, image, last_strength, start_percent, end_percent)])
+                values.append([(control_net_name, image, last_strength, start_percent, end_percent, control_net)])
 
         elif target_parameter == "start_percent":
             axis = "advanced: ControlNetStart%"
 
             percent_increment = (last_start_percent - first_start_percent) / (batch_count - 1) if batch_count > 1 else 0
-            values.append([(control_net_name, image, strength, first_start_percent, end_percent)])
+            values.append([(control_net_name, image, strength, first_start_percent, end_percent, control_net)])
             for i in range(1, batch_count - 1):
                 values.append([(control_net_name, image, strength, first_start_percent + i * percent_increment,
-                                  end_percent)])
+                                  end_percent, control_net)])
 
             # Always add the last start_percent if batch_count is more than 1.
             if batch_count > 1:
-                values.append((control_net_name, image, strength, last_start_percent, end_percent))
+                values.append([(control_net_name, image, strength, last_start_percent, end_percent, control_net)])
 
         elif target_parameter == "end_percent":
             axis = "advanced: ControlNetEnd%"
 
             percent_increment = (last_end_percent - first_end_percent) / (batch_count - 1) if batch_count > 1 else 0
-            values.append([(control_net_name, image, image, strength, start_percent, first_end_percent)])
+            values.append([(control_net_name, image, strength, start_percent, first_end_percent, control_net)])
             for i in range(1, batch_count - 1):
                 values.append([(control_net_name, image, strength, start_percent,
-                                  first_end_percent + i * percent_increment)])
+                                  first_end_percent + i * percent_increment, control_net)])
 
             if batch_count > 1:
-                values.append([(control_net_name, image, strength, start_percent, last_end_percent)])
+                values.append([(control_net_name, image, strength, start_percent, last_end_percent, control_net)])
 
 
         return ({"axis": axis, "values": values},)


### PR DESCRIPTION
Added a Controlnet input to the `XY Inputs: Controlnet` node. When this is provided, controlnet will not be loaded using the name input (should be the same behavior as the EasyControlnet pipe nodes), defaults to `None`.

Didn't find a way to plug an existing controlnet model into the XY Inputs node, so thought I'd add one.

<img width="1292" height="881" alt="image" src="https://github.com/user-attachments/assets/b1bdfdd1-ae83-4126-a8dc-54f0ccd5d437" />
