### PR TITLE
Fix: Add max parameter to wildcardsPromptMatrix offset

### DIFF
--- a/py/nodes/prompt.py
+++ b/py/nodes/prompt.py
@@ -94,7 +94,7 @@ class wildcardsPromptMatrix:
             "text": ("STRING", {"default": "", "multiline": True, "dynamicPrompts": False, "placeholder": "(Support Lora Block Weight and wildcard)"}),
             "Select to add LoRA": (["Select the LoRA to add to the text"] + folder_paths.get_filename_list("loras"),),
             "Select to add Wildcard": (["Select the Wildcard to add to the text"] + wildcard_list,),
-            "offset": ("INT", {"default": 0, "min": 0, "step": 1, "control_after_generate": True}),
+            "offset": ("INT", {"default": 0, "min": 0, "max": MAX_SEED_NUM, "step": 1, "control_after_generate": True}),
             },
             "optional":{
               "output_limit": ("INT", {"default": 1, "min": -1, "step": 1, "tooltip": "Output All Probilities"})


### PR DESCRIPTION
 - Set offset max to MAX_SEED_NUM (1125899906842624) instead of default 2048
 - This allows accessing all items in large wildcards (e.g., 100k lines)
- Previously, only the first 2048 items were accessible due to ComfyUI frontend default limit