### PR TITLE
FIX bypass imageColorMatch node pass the reference image.

### DIFF
--- a/py/nodes/image.py
+++ b/py/nodes/image.py
@@ -1079,8 +1079,8 @@ class imageColorMatch(PreviewImage):
   def INPUT_TYPES(cls):
     return {
       "required": {
-        "image_ref": ("IMAGE",),
         "image_target": ("IMAGE",),
+        "image_ref": ("IMAGE",),
         "method": (['wavelet', 'adain', 'mkl', 'hm', 'reinhard', 'mvgd', 'hm-mvgd-hm', 'hm-mkl-hm'],),
         "image_output": (["Hide", "Preview", "Save", "Hide/Save"], {"default": "Preview"}),
         "save_prefix": ("STRING", {"default": "ComfyUI"}),


### PR DESCRIPTION
When bypass the imageColorMatch node, it passes the reference image (image_ref) instead of the target image (image_target).

Swap the order of the two image inputs in INPUT_TYPES: After this change → bypass will correctly pass the target image.