### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 name = "comfyui-easy-use"
 description = "To enhance the usability of ComfyUI, optimizations and integrations have been implemented for several commonly used nodes."
 version = "1.3.5"
-license = { file = "LICENSE" }
+license = "GPL-3.0-only"
+license-files = [ "LICENSE" ]
 dependencies = ["diffusers", "accelerate", "clip_interrogator>=0.6.0", "sentencepiece", "lark", "onnxruntime", "spandrel", "opencv-python-headless", "matplotlib", "peft"]
 
 [project.urls]
@@ -13,3 +14,6 @@ Repository = "https://github.com/yolain/ComfyUI-Easy-Use"
 PublisherId = "yolain"
 DisplayName = "ComfyUI-Easy-Use"
 Icon = "https://mintlify.s3.us-west-1.amazonaws.com/yolain/images/logo.svg"
+
+[tool.setuptools.packages]
+find = {}


### PR DESCRIPTION
from python 3.13 i wasn't able to "pip install ." until I made these changes.
see also 
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files
and
https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#custom-discovery