### PR TITLE
Fix for loraStack/loraSwitcher/controlnetStack disable erases upstream stack

### DIFF
--- a/py/nodes/loaders.py
+++ b/py/nodes/loaders.py
@@ -1175,9 +1175,12 @@ class loraSwitcher:
 
     CATEGORY = "EasyUse/Loaders"
 
-    def stack(self, toggle, select,num_loras, lora_strength, optional_lora_stack=None, **kwargs):
-        if (toggle in [False, None, "False"]) or not kwargs:
-            return (None,'')
+    def stack(self, toggle, select,num_loras, lora_strength, optional_lora_stack=None, **kwargs):     
+        if toggle in [False, None, "False"]:
+            return (optional_lora_stack, '')
+
+        if not kwargs and optional_lora_stack is None:
+            return (None, '')
 
         loras = []
 
@@ -1234,7 +1237,10 @@ class loraStack:
     CATEGORY = "EasyUse/Loaders"
 
     def stack(self, toggle, mode, num_loras, optional_lora_stack=None, **kwargs):
-        if (toggle in [False, None, "False"]) or not kwargs:
+        if toggle in [False, None, "False"]:
+            return (optional_lora_stack,)
+
+        if not kwargs and optional_lora_stack is None:
             return (None,)
 
         loras = []
@@ -1291,7 +1297,10 @@ class controlnetStack:
     CATEGORY = "EasyUse/Loaders"
 
     def stack(self, toggle, mode, num_controlnet, optional_controlnet_stack=None, **kwargs):
-        if (toggle in [False, None, "False"]) or not kwargs:
+        if toggle in [False, None, "False"]:
+            return (optional_controlnet_stack,)
+
+        if not kwargs and optional_controlnet_stack is None:
             return (None,)
 
         controlnets = []


### PR DESCRIPTION
When 'toggle' is set to 'Disabled' in a loraStack, loraSwitcher, or controlnetStack node, the node returns None, which erases the upstream 'optional_lora_stack' from chained nodes.

In a chain of these nodes, disabling a middle node removes all upsteam selections.

This PR changes these nodes so that when disabled, they pass through any upstream 'optional_lora_stack' unchanged. 

