### PR TITLE
fix: use getattr for flipped_img_txt compatibility

### DIFF
--- a/py/modules/ipadapter/flux/layers.py
+++ b/py/modules/ipadapter/flux/layers.py
@@ -28,7 +28,7 @@ class DoubleStreamBlockIPA(nn.Module):
 
         self.txt_norm2 = original_block.txt_norm2
         self.txt_mlp = original_block.txt_mlp
-        self.flipped_img_txt = original_block.flipped_img_txt
+        self.flipped_img_txt = getattr(original_block, 'flipped_img_txt', False)
 
         self.ip_adapter = ip_adapter
         self.image_emb = image_emb


### PR DESCRIPTION
## Summary

ComfyUI removed the `flipped_img_txt` attribute from `DoubleStreamBlock` in a recent refactor (commit e1add563f, "Use torch RMSNorm for flux models and refactor hunyuan video code"). This causes an `AttributeError` in `py/modules/ipadapter/flux/layers.py` when IPAdapter Flux nodes are executed:

```
AttributeError: 'DoubleStreamBlock' object has no attribute 'flipped_img_txt'
```

This PR uses `getattr` with a default of `False` (matching the original default value) to maintain compatibility with both old and new ComfyUI versions.

## Changes

- `py/modules/ipadapter/flux/layers.py`: Replace direct attribute access with `getattr(original_block, 'flipped_img_txt', False)`