### PR TITLE
Fix Clean VRAM teardown ordering and clear Easy-Use cache in place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ docs/**
 mmb-preset.custom.txt
 config.yaml
 node.tar.gz
+.codex
 
 .cursorrules
 tools/ComfyUI-Easy-Use.json

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ web_beta/**
 web_version/dev/**
 docs/**
 .vscode/
+.vs/
 .idea/
 .claude/**
 mmb-preset.custom.txt

--- a/py/libs/cache.py
+++ b/py/libs/cache.py
@@ -77,10 +77,11 @@ def update_cache(k, tag, v):
     else:
         cache_count[k] += 1
 def remove_cache(key):
-    global cache
     if key == '*':
-        cache = TaggedCache(cache_settings)
+        cache.clear()
+        cache_count.clear()
     elif key in cache:
         del cache[key]
+        cache_count.pop(key, None)
     else:
         print(f"invalid {key}")

--- a/py/libs/utils.py
+++ b/py/libs/utils.py
@@ -35,9 +35,13 @@ import sys
 import importlib.util
 import importlib.metadata
 import comfy.model_management as mm
+import logging
 import gc
 from packaging import version
 from server import PromptServer
+
+LOG = logging.getLogger(__name__)
+
 def is_package_installed(package):
     try:
         module = importlib.util.find_spec(package)
@@ -283,11 +287,14 @@ def cleanGPUUsedForce():
     gc.collect()
     try:
         import torch
-
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()
-    except Exception:
-        pass
+    except (ImportError, OSError, RuntimeError) as exc:
+        LOG.debug("Skipping CUDA synchronize during cleanGPUUsedForce: torch import failed: %s", exc)
+    else:
+        try:
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+        except (AttributeError, OSError, RuntimeError) as exc:
+            LOG.debug("Skipping CUDA synchronize during cleanGPUUsedForce: %s", exc)
 
     mm.unload_all_models()
     mm.soft_empty_cache()

--- a/py/libs/utils.py
+++ b/py/libs/utils.py
@@ -277,6 +277,17 @@ def getMetadata(filepath):
         return header
 
 def cleanGPUUsedForce():
+    from .cache import remove_cache
+
+    remove_cache("*")
     gc.collect()
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+    except Exception:
+        pass
+
     mm.unload_all_models()
     mm.soft_empty_cache()

--- a/py/nodes/logic.py
+++ b/py/nodes/logic.py
@@ -1420,7 +1420,6 @@ class cleanGPUUsed(io.ComfyNode):
     @classmethod
     def execute(cls, anything, **kwargs):
         cleanGPUUsedForce()
-        remove_cache("*")
         return io.NodeOutput(anything)
 
 

--- a/py/routes.py
+++ b/py/routes.py
@@ -25,7 +25,6 @@ def get_version(request):
 def cleanGPU(request):
     try:
         cleanGPUUsedForce()
-        remove_cache('*')
         return web.Response(status=200)
     except Exception as e:
         return web.Response(status=500)


### PR DESCRIPTION
## Summary
This fixes the Easy-Use Clean VRAM path so extension-owned cache references are dropped before aggressive model unload / CUDA cache cleanup runs.

In my testing, this resolved an intermittent WSL freeze / wedge when running a mixed workflow with multiple SDXL samplers, SeedVR2 upscales, and FLUX.2 passes, then cleaning VRAM mid-workflow before the next upscale stage.

## Problem
The Clean VRAM flow had two core correctness issues:

- `remove_cache("*")` replaced the shared `cache` object instead of clearing it in place
- the Clean VRAM path unloaded models before Easy-Use cache references were dropped

That combination could leave stale imported cache references alive across modules and make teardown after heavy phases more fragile, especially when cleaning VRAM in the middle of a workflow.

There was also no explicit CUDA synchronization before teardown, which made the cleanup boundary more brittle in my WSL setup after a FLUX.2 pass.

## Changes
- change `remove_cache("*")` to clear the existing cache object in place
- clear `cache_count` bookkeeping together with the cache contents
- remove per-key bookkeeping on single-key cache removal
- move `remove_cache("*")` into `cleanGPUUsedForce()` so cache refs are dropped before model unload
- add a guarded `torch.cuda.synchronize()` before teardown
- narrow exception handling around the CUDA sync path and log at debug level when sync is skipped
- remove the now-redundant follow-up `remove_cache("*")` calls from the node and route handlers
- ignore `.vs/` in `.gitignore`

## Why this matters
This preserves a single shared cache object for all importers and fixes teardown ordering so Easy-Use does not keep stale references alive while ComfyUI is unloading models and emptying CUDA cache.

In practice, this makes the Clean VRAM node more reliable at heavy model-family boundaries.

## Repro context
This was observed in a workflow that looked roughly like:

- 3x SDXL samplers
- SeedVR2 upscale
- FLUX.2 pass
- Clean VRAM
- another SeedVR2 upscale

The sporadic freeze happened intermittently on WSL when hitting Clean VRAM after the FLUX.2 pass. After this change, that freeze appears to be gone in that setup.

## Scope
This PR is intentionally narrow and only touches the Clean VRAM / cache clearing path. It does not change normal generation logic outside teardown.