### PR TITLE
fix showAnything list output semantics

### DIFF
--- a/py/nodes/logic.py
+++ b/py/nodes/logic.py
@@ -1274,7 +1274,7 @@ class showAnything(io.ComfyNode):
             is_input_list=True,
             is_output_node=True,
             inputs=[io.AnyType.Input("anything", optional=True)],
-            outputs=[io.AnyType.Output("output")],
+            outputs=[io.AnyType.Output("output", is_output_list=True)],
             hidden=[io.Hidden.unique_id, io.Hidden.extra_pnginfo],
         )
 
@@ -1307,8 +1307,7 @@ class showAnything(io.ComfyNode):
             if node:
                 node["widgets_values"] = [values]
 
-        result_val = values[0] if (isinstance(values, list) and len(values) == 1) else values
-        return io.NodeOutput(result_val, ui={"text": values})
+        return io.NodeOutput(values, ui={"text": values})
 
 
 class showTensorShape(io.ComfyNode):


### PR DESCRIPTION
## What changed

This restores list semantics for `easy showAnything` in the v3 node definition.

- marks the `output` socket as `is_output_list=True`
- stops collapsing a one-item list into a scalar before returning `NodeOutput`

## Root cause

`easy showAnything` accepts list inputs (`is_input_list=True`), but its v3 output schema currently advertises a non-list output and its execution path collapses single-item lists into scalars.

That makes list-producing upstream nodes inconsistent when routed through `easy showAnything`, especially for downstream nodes that depend on list-aware output behavior.

## Impact

`easy showAnything` now preserves list outputs instead of degrading them into scalar wildcard outputs.

## Validation

- `python3 -m py_compile py/nodes/logic.py`
- compared against the live installed node metadata, where `easy outputToList` already advertises `output_is_list: [True]` while `easy showAnything` currently advertises `output_is_list: [False]`
