### PR TITLE
fix: preserve existing canvas background hook

### DIFF
--- a/web_version/v1/js/easy/easyWidgets.js
+++ b/web_version/v1/js/easy/easyWidgets.js
@@ -183,6 +183,31 @@ document.head.appendChild(styleElement);
 
 const InfoSymbol = Symbol();
 const InfoResizeSymbol = Symbol();
+const EASY_INFO_BACKGROUND_HOOK = "__easyUseInfoWidgetOnDrawBackgroundHook";
+
+function moveInfoWidgetsOffscreen() {
+	for (const node of app.graph?._nodes || []) {
+		for (const widget of node.widgets || []) {
+			if (Object.hasOwn(widget, "inputEl")) {
+				widget.inputEl.style.left = "-8000px";
+				widget.inputEl.style.position = "absolute";
+			}
+		}
+	}
+}
+
+function ensureInfoWidgetBackgroundHook() {
+	if (app.canvas[EASY_INFO_BACKGROUND_HOOK]) {
+		return;
+	}
+
+	const onDrawBackground = app.canvas.onDrawBackground;
+	app.canvas.onDrawBackground = function (...args) {
+		onDrawBackground?.apply(this, args);
+		moveInfoWidgetsOffscreen();
+	};
+	app.canvas[EASY_INFO_BACKGROUND_HOOK] = true;
+}
 
 
 
@@ -285,21 +310,7 @@ function addInfoWidget(node, name, opts, app) {
 
 	node.addCustomWidget(widget);
 
-	app.canvas.onDrawBackground = function () {
-		// Draw node isnt fired once the node is off the screen
-		// if it goes off screen quickly, the input may not be removed
-		// this shifts it off screen so it can be moved back if the node is visible.
-		for (let n in app.graph._nodes) {
-			n = app.graph._nodes[n];
-			for (let w in n.widgets) {
-				let wid = n.widgets[w];
-				if (Object.hasOwn(wid, "inputEl")) {
-					wid.inputEl.style.left = -8000 + "px";
-					wid.inputEl.style.position = "absolute";
-				}
-			}
-		}
-	};
+	ensureInfoWidgetBackgroundHook();
 
 	node.onRemoved = function () {
 		// When removing this node we need to remove the input from the DOM

--- a/web_version/v1/js/poseEditor.js
+++ b/web_version/v1/js/poseEditor.js
@@ -68,6 +68,32 @@ const default_keypoints = [
   [260, 72],
 ];
 
+const POSE_EDITOR_BACKGROUND_HOOK = "__easyUsePoseEditorOnDrawBackgroundHook";
+
+function movePoseEditorWidgetsOffscreen() {
+  for (const node of app.graph?._nodes || []) {
+    for (const widget of node.widgets || []) {
+      if (Object.hasOwn(widget, "openpose")) {
+        widget.openpose.style.left = "-8000px";
+        widget.openpose.style.position = "absolute";
+      }
+    }
+  }
+}
+
+function ensurePoseEditorBackgroundHook() {
+  if (app.canvas[POSE_EDITOR_BACKGROUND_HOOK]) {
+    return;
+  }
+
+  const onDrawBackground = app.canvas.onDrawBackground;
+  app.canvas.onDrawBackground = function (...args) {
+    onDrawBackground?.apply(this, args);
+    movePoseEditorWidgetsOffscreen();
+  };
+  app.canvas[POSE_EDITOR_BACKGROUND_HOOK] = true;
+}
+
 class OpenPose {
   constructor(node, canvasElement) {
     this.lockMode = false;
@@ -556,21 +582,7 @@ function createOpenPose(node, inputName, inputData, app) {
     widget.openpose?.remove();
   };
 
-  app.canvas.onDrawBackground = function () {
-    // Draw node isnt fired once the node is off the screen
-    // if it goes off screen quickly, the input may not be removed
-    // this shifts it off screen so it can be moved back if the node is visible.
-    for (let n in app.graph._nodes) {
-      n = graph._nodes[n];
-      for (let w in n.widgets) {
-        let wid = n.widgets[w];
-        if (Object.hasOwn(wid, "openpose")) {
-          wid.openpose.style.left = -8000 + "px";
-          wid.openpose.style.position = "absolute";
-        }
-      }
-    }
-  };
+  ensurePoseEditorBackgroundHook();
   return { widget: widget };
 }
 


### PR DESCRIPTION
## Summary

This change avoids clobbering `app.canvas.onDrawBackground` when Easy-Use installs its DOM widget cleanup logic.

## Tested environment

- ComfyUI core: `v0.24.0`
- ComfyUI commit: `f49bdb65`
- comfyui-frontend-package: `1.44.19`

Validated in a multi-extension setup on the classic / non-Vue node path.

## Problem

The current implementation directly replaces `app.canvas.onDrawBackground` in multiple places.

That works in isolation, but when multiple extensions are loaded, replacing the global canvas background hook can break other extensions that also rely on it for DOM widget positioning / cleanup.

## Changes

- keep the existing `app.canvas.onDrawBackground` handler
- wrap it instead of replacing it outright
- run the Easy-Use off-screen DOM widget cleanup after the previous handler

Affected areas:
- info widget DOM input cleanup
- pose editor DOM widget cleanup

## Why this helps

This keeps Easy-Use behavior intact while allowing other extensions to keep their own background hook logic.

In other words, this is a coexistence / compatibility fix rather than a behavior change.

## Manual validation

Validated manually in a multi-extension ComfyUI setup where multiple nodes use DOM widgets and canvas background hooks at the same time.