### PR TITLE
fix(imageDetailTransfer): multi-frame masks crash on channel broadcast

### DIFF
--- a/py/nodes/image.py
+++ b/py/nodes/image.py
@@ -1218,6 +1218,8 @@ class imageDetailTransfer:
     new_image = torch.lerp(target_tensor, new_image, blend_factor)
     if mask is not None:
       mask = mask.to(device)
+      if mask.dim() == 3:  # (B,H,W) batch/video mask -> (B,1,H,W) so it broadcasts over channels
+        mask = mask.unsqueeze(1)
       new_image = torch.lerp(target_tensor, new_image, mask)
     new_image = torch.clamp(new_image, 0, 1)
     new_image = new_image.permute(0, 2, 3, 1).cpu().float()


### PR DESCRIPTION
### Bug

`imageDetailTransfer` crashes when the optional `mask` has more than one frame (a per-frame video matte, e.g. a SAM2 alpha over a clip):

```
RuntimeError: The size of tensor a (3) must match the size of tensor b (52) at non-singleton dimension 1
```

The mask is interpolated to shape `(B, H, W)`, then used in `torch.lerp(target_tensor, new_image, mask)` where the image tensors are channels-first `(B, C, H, W)`. Broadcasting right-aligns `(B, H, W)` as `(1, B, H, W)`, so dimension 1 compares `C` (3) against `B` and fails for any `B > 1`. A single-frame mask only works by accident.

### Fix

Insert the missing channel dimension (`(B, H, W)` -> `(B, 1, H, W)`) before the lerp, so the mask broadcasts over channels and applies per frame.

### Repro

```python
target = torch.rand(52, 2160, 3840, 3)  # video batch
source = torch.rand(52, 2160, 3840, 3)
mask   = torch.rand(52, 2160, 3840)     # per-frame matte -> crashes before this patch
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)