### PR TITLE
fix(promptConcat): TypeError when an input is a list

### DIFF
--- a/py/nodes/prompt.py
+++ b/py/nodes/prompt.py
@@ -396,7 +396,12 @@ class promptConcat(io.ComfyNode):
 
     @classmethod
     def execute(cls, prompt1="", prompt2="", separator=""):
-        return io.NodeOutput(prompt1 + separator + prompt2)
+        def to_string(value):
+            if isinstance(value, (list, tuple)):
+                return ", ".join(to_string(v) for v in value)
+            return str(value)
+
+        return io.NodeOutput(to_string(prompt1) + to_string(separator) + to_string(prompt2))
 
 class promptReplace(io.ComfyNode):
 


### PR DESCRIPTION
Fixes #993

`easy promptConcat` raised `TypeError: can only concatenate list (not "str") to list` when an upstream node (e.g. WD14 tagger pipelines) outputs a list of strings, and the list leaking downstream caused `write() argument must be str` in save nodes.

Change: normalize `prompt1`/`prompt2`/`separator` to strings before concatenation (lists joined with `", "`, matching existing conventions in prompt.py), guaranteeing a plain string output. Plain-string behavior is unchanged.