### PR TITLE
fix(preSampling): IP2P guider raises TypeError when fed a latent instead of an image

### DIFF
--- a/py/nodes/preSampling.py
+++ b/py/nodes/preSampling.py
@@ -367,7 +367,7 @@ class samplerCustomSettings:
     FUNCTION = "settings"
     CATEGORY = "EasyUse/PreSampling"
 
-    def ip2p(self, positive, negative, vae, pixels, latent=None):
+    def ip2p(self, positive, negative, vae=None, pixels=None, latent=None):
         if latent is not None:
             concat_latent = latent
         else:


### PR DESCRIPTION
### Problem

`samplerCustomSettings.ip2p` in `py/nodes/preSampling.py` has two call sites in the same method, and the second one cannot bind:

```python
# line 415 — image branch
positive, negative, latent = self.ip2p(pipe['positive'], pipe['negative'], vae, image_to_latent)

# line 423 — latent branch
positive, negative, latent = self.ip2p(pipe['positive'], pipe['negative'], latent=latent)
```

against the definition at line 370:

```python
def ip2p(self, positive, negative, vae, pixels, latent=None):
```

So picking an **IP2P** guider while feeding the node a latent (rather than an image) raises

```
TypeError: ip2p() missing 2 required positional arguments: 'vae' and 'pixels'
```

The method body never touches `vae` or `pixels` on that path — it short-circuits on the first line:

```python
if latent is not None:
    concat_latent = latent
else:
    ... pixels ... vae.encode(pixels)
```

so the latent branch is only unreachable because of the signature.

### Why the fix is unambiguous

The repo already contains the corrected copy of this exact method. `samplerFull.ip2p` in `py/nodes/samplers.py:60` is byte-identical to `samplerCustomSettings.ip2p` apart from the defaults (and one whitespace difference):

```diff
--- preSampling.ip2p
+++ samplers.ip2p
-def ip2p(self, positive, negative, vae, pixels, latent=None):
+def ip2p(self, positive, negative, vae=None, pixels=None, latent=None):
         if latent is not None:
...
-                pixels = pixels[:,x_offset:x + x_offset, y_offset:y + y_offset,:]
+                pixels = pixels[:, x_offset:x + x_offset, y_offset:y + y_offset, :]
```

This PR just brings `preSampling.py`'s copy in line with `samplers.py`'s — one line, defaults only, no behaviour change to the image branch.

### Verification

Signature replay against the real source (parameters extracted from `preSampling.py` with `ast`, then `inspect.Signature.bind`), with the working image-branch call as the control:

```
samplerCustomSettings.ip2p def@370 (self, positive, negative, vae, pixels, latent=None)
    line 415: (pos, neg, vae, pixels)    -> OK
    line 423: (pos, neg, latent=latent)  -> TypeError: missing a required argument: 'vae'
```

I don't have a ComfyUI instance with IP2P models set up here, so this is a static verification of the call rather than a graph run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
