### PR TITLE
fix(pixart): ControlPixArtHalf/MSHalf 用的 lewei_scale 早已改名 pe_interpolation，两个 ControlNet target 必崩

### DIFF
--- a/py/modules/dit/pixArt/models/pixart_controlnet.py
+++ b/py/modules/dit/pixArt/models/pixart_controlnet.py
@@ -77,7 +77,7 @@ class ControlPixArtHalf(Module):
 
     def forward_c(self, c):
         self.h, self.w = c.shape[-2]//self.patch_size, c.shape[-1]//self.patch_size
-        pos_embed = torch.from_numpy(get_2d_sincos_pos_embed(self.pos_embed.shape[-1], (self.h, self.w), lewei_scale=self.lewei_scale, base_size=self.base_size)).unsqueeze(0).to(c.device).to(self.dtype)
+        pos_embed = torch.from_numpy(get_2d_sincos_pos_embed(self.pos_embed.shape[-1], (self.h, self.w), pe_interpolation=self.pe_interpolation, base_size=self.base_size)).unsqueeze(0).to(c.device).to(self.dtype)
         return self.x_embedder(c) + pos_embed if c is not None else c
 
     # def forward(self, x, t, c, **kwargs):
@@ -225,7 +225,7 @@ class ControlPixArtMSHalf(ControlPixArtHalf):
         c_size, ar = data_info['img_hw'].to(self.dtype), data_info['aspect_ratio'].to(self.dtype)
         self.h, self.w = x.shape[-2]//self.patch_size, x.shape[-1]//self.patch_size
 
-        pos_embed = torch.from_numpy(get_2d_sincos_pos_embed(self.pos_embed.shape[-1], (self.h, self.w), lewei_scale=self.lewei_scale, base_size=self.base_size)).unsqueeze(0).to(x.device).to(self.dtype)
+        pos_embed = torch.from_numpy(get_2d_sincos_pos_embed(self.pos_embed.shape[-1], (self.h, self.w), pe_interpolation=self.pe_interpolation, base_size=self.base_size)).unsqueeze(0).to(x.device).to(self.dtype)
         x = self.x_embedder(x) + pos_embed  # (N, T, D), where T = H * W / patch_size ** 2
         t = self.t_embedder(timestep)  # (N, D)
         csize = self.csize_embedder(c_size, bs)  # (N, D)


### PR DESCRIPTION
### 问题

`ControlPixArtHalf` / `ControlPixArtMSHalf` 这两个 PixArt ControlNet target 一跑就崩：

```python
# py/modules/dit/pixArt/models/pixart_controlnet.py:80  (ControlPixArtHalf.forward_c)
pos_embed = torch.from_numpy(get_2d_sincos_pos_embed(
    self.pos_embed.shape[-1], (self.h, self.w),
    lewei_scale=self.lewei_scale, base_size=self.base_size))
# 同样的一行也出现在 :228 (ControlPixArtMSHalf.forward_raw)
```

`lewei_scale` 是 PixArt 上游改名前的旧名字，改名后叫 `pe_interpolation`。这个文件是唯一还留着旧名字的地方：

```console
$ grep -rn "lewei_scale\|pe_interpolation" py/modules/dit/pixArt/
...  config.py:20,34,49,64,78     "pe_interpolation": ...
...  loader.py:149,169,175        config["pe_interpolation"] = ...
...  models/PixArt.py:74,88,201,209,210
...  models/PixArtMS.py:101,122,173,174,176,181
...  models/pixart_controlnet.py:80,228   <-- 只有这两行是 lewei_scale
```

所以：

1. `self.lewei_scale` —— `ControlPixArtHalf.__getattr__` 会把未知属性转发到 `self.base_model`（一个 `PixArt` / `PixArtMS`），而它上面只有 `self.pe_interpolation`（`PixArt.py:88`），于是先抛
   `AttributeError: 'PixArtMS' object has no attribute 'lewei_scale'`；
2. 就算属性存在，`get_2d_sincos_pos_embed(embed_dim, grid_size, cls_token=False, extra_tokens=0, pe_interpolation=1.0, base_size=16)` 也不收 `lewei_scale`，是 `TypeError`。

### 可达性

两处都在活路径上：`forward_c` 由 `ControlPixArtHalf.forward_raw`（:89）和 `ControlPixArtMSHalf.forward_raw`（:220）调用，而这两个 target 在 `config.py` 里注册、由 `loader.py:100-109` 实例化。

### 修法

按同仓正确写法（`PixArtMS.py:181` 的 `get_2d_sincos_pos_embed(..., pe_interpolation=pe_interpolation, base_size=self.base_size)`）对齐，直接把两行的旧名字换成新名字：

```diff
-    lewei_scale=self.lewei_scale, base_size=self.base_size
+    pe_interpolation=self.pe_interpolation, base_size=self.base_size
```

`self.pe_interpolation` 一定有值：两个 ControlNet 配置分别复用 `PixArt_XL_2` / `PixArtMS_XL_2` 的 `unet_config`，里面写死了 `"pe_interpolation": 2`。

改动 2 行，行为等价于改名前。`PixArtMS.forward_raw` 里那段 `pe_interpolation is None` 时按分辨率现算的逻辑没有搬过来 —— 那是另一个话题，本 PR 不动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
