### PR TITLE
fix: confine Save Text outputs to ComfyUI output directory

### DIFF
--- a/py/libs/path_utils.py
+++ b/py/libs/path_utils.py
@@ -1,0 +1,29 @@
+import os
+
+
+def resolve_output_file_path(output_root, output_file_path, file_name, file_extension):
+    """Resolve a workflow-provided output path beneath ``output_root``.
+
+    Relative output directories remain supported, but are interpreted relative
+    to ComfyUI's configured output directory rather than the process working
+    directory. Resolving both paths prevents ``..`` components and existing
+    symlinks from escaping the allowed root.
+    """
+    output_root = os.path.realpath(output_root)
+    requested_directory = output_file_path
+    if not os.path.isabs(requested_directory):
+        requested_directory = os.path.join(output_root, requested_directory)
+
+    candidate = os.path.realpath(
+        os.path.join(requested_directory, f"{file_name}.{file_extension}")
+    )
+    try:
+        is_within_output = os.path.commonpath((output_root, candidate)) == output_root
+    except ValueError:
+        # Different Windows drives and paths containing null bytes are unsafe.
+        is_within_output = False
+
+    if not is_within_output:
+        raise ValueError("Saving outside the ComfyUI output directory is not allowed")
+
+    return candidate

--- a/py/nodes/logic.py
+++ b/py/nodes/logic.py
@@ -8,6 +8,7 @@ from ..libs.utils import AlwaysEqualProxy, ByPassTypeTuple, cleanGPUUsedForce, c
 from ..libs.cache import cache, update_cache, remove_cache
 from ..libs.log import log_node_info, log_node_warn
 from ..libs.math import evaluate_formula
+from ..libs.path_utils import resolve_output_file_path
 import numpy as np
 import time
 import os
@@ -1585,9 +1586,14 @@ class saveText(io.ComfyNode):
             log_node_warn("Save Text", "No file details found. No file output.")
             return io.NodeOutput(text, None)
 
-        filepath = os.path.join(output_file_path, file_name) + "." + file_extension
-        if not os.path.exists(output_file_path):
-            os.makedirs(output_file_path)
+        if file_extension not in ("txt", "csv"):
+            raise ValueError("Unsupported text file extension")
+
+        output_dir = folder_paths.get_output_directory()
+        filepath = resolve_output_file_path(
+            output_dir, output_file_path, file_name, file_extension
+        )
+        os.makedirs(os.path.dirname(filepath), exist_ok=True)
 
         file_mode = "w" if overwrite else "a"
         log_node_info("Save Text", f"Saving to {filepath}")
@@ -1604,27 +1610,24 @@ class saveText(io.ComfyNode):
 
         result_image = None
         if image is not None:
-            imagepath = os.path.join(output_file_path, file_name)
-            index = 1
+            imagepath = resolve_output_file_path(
+                output_dir, output_file_path, file_name, "png"
+            )
             if not overwrite:
-                while os.path.exists(filepath):
-                    imagepath = os.path.join(output_file_path, file_name) + "_" + str(index)
+                index = 1
+                while os.path.exists(imagepath):
+                    imagepath = resolve_output_file_path(
+                        output_dir, output_file_path, f"{file_name}_{index}", "png"
+                    )
                     index += 1
 
-            output_dir = folder_paths.output_directory
-            output_path_val = "" if output_file_path in [None, "", "none", "."] else output_file_path
-            if not os.path.isabs(output_file_path):
-                output_path_val = os.path.join(output_dir, output_path_val)
-            if output_path_val.strip():
-                if not os.path.isabs(output_path_val):
-                    output_path_val = os.path.join(folder_paths.output_directory, output_path_val)
-                if not os.path.exists(output_path_val.strip()):
-                    print(f"The path `{output_path_val.strip()}` does not exist! Creating directory.")
-                    os.makedirs(output_path_val, exist_ok=True)
+            image_output_path = os.path.dirname(imagepath)
+            os.makedirs(image_output_path, exist_ok=True)
 
             images_tensor = torch.cat([image], dim=0)
-            cls.save_image(images_tensor, imagepath, "png", 100, None, None,
-                           filename_number_start="true", output_path=output_path_val,
+            image_name = os.path.splitext(os.path.basename(imagepath))[0]
+            cls.save_image(images_tensor, image_name, "png", 100, None, None,
+                           filename_number_start="true", output_path=image_output_path,
                            delimiter="_", number_padding=4, lossless_webp=False)
             log_node_info("Save Text", f"Saving Image to {imagepath}")
             result_image = image

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -1,0 +1,71 @@
+import importlib.util
+import os
+from pathlib import Path
+import tempfile
+import unittest
+
+
+MODULE_PATH = Path(__file__).parents[1] / "py" / "libs" / "path_utils.py"
+SPEC = importlib.util.spec_from_file_location("easyuse_path_utils", MODULE_PATH)
+path_utils = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(path_utils)
+
+
+class ResolveOutputFilePathTests(unittest.TestCase):
+    def test_relative_subdirectory_is_resolved_under_output_root(self):
+        with tempfile.TemporaryDirectory() as output_root:
+            result = path_utils.resolve_output_file_path(
+                output_root, "metadata", "prompt", "txt"
+            )
+
+            self.assertEqual(
+                result,
+                os.path.join(os.path.realpath(output_root), "metadata", "prompt.txt"),
+            )
+
+    def test_absolute_directory_inside_output_root_is_allowed(self):
+        with tempfile.TemporaryDirectory() as output_root:
+            inside = os.path.join(output_root, "metadata")
+
+            result = path_utils.resolve_output_file_path(
+                output_root, inside, "prompt", "txt"
+            )
+
+            self.assertEqual(result, os.path.join(inside, "prompt.txt"))
+
+    def test_absolute_directory_outside_output_root_is_rejected(self):
+        with tempfile.TemporaryDirectory() as output_root:
+            with tempfile.TemporaryDirectory() as outside:
+                with self.assertRaises(ValueError):
+                    path_utils.resolve_output_file_path(
+                        output_root, outside, "marker", "txt"
+                    )
+
+    def test_output_directory_traversal_is_rejected(self):
+        with tempfile.TemporaryDirectory() as output_root:
+            with self.assertRaises(ValueError):
+                path_utils.resolve_output_file_path(
+                    output_root, "../outside", "marker", "txt"
+                )
+
+    def test_file_name_traversal_is_rejected(self):
+        with tempfile.TemporaryDirectory() as output_root:
+            with self.assertRaises(ValueError):
+                path_utils.resolve_output_file_path(
+                    output_root, ".", "../../marker", "txt"
+                )
+
+    @unittest.skipUnless(hasattr(os, "symlink"), "symlinks are unavailable")
+    def test_symlink_escape_is_rejected(self):
+        with tempfile.TemporaryDirectory() as output_root:
+            with tempfile.TemporaryDirectory() as outside:
+                os.symlink(outside, os.path.join(output_root, "linked"))
+
+                with self.assertRaises(ValueError):
+                    path_utils.resolve_output_file_path(
+                        output_root, "linked", "marker", "txt"
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- resolve Save Text destinations beneath ComfyUI's configured output directory
- reject absolute paths outside that root, parent traversal, filename traversal, and existing symlink escapes
- apply the same confinement to the node's optional companion image output
- restrict execution to the declared `txt` and `csv` extensions
- add focused regression tests for allowed and rejected paths

Relative output subdirectories continue to work, but are now interpreted relative to ComfyUI's output directory instead of the process working directory. Absolute directories are supported only when they resolve inside the configured output root.

## Verification

- `python -m unittest discover -s tests -v` (6 tests pass)
- `python -m py_compile py/libs/path_utils.py py/nodes/logic.py`
- `git diff --check`

Closes #1031
