### PR TITLE
New logic node: Pass or None

### DIFF
--- a/locales/en/nodeDefs.json
+++ b/locales/en/nodeDefs.json
@@ -6271,6 +6271,22 @@
       }
     }
   },
+  "easy PassOrNone": {
+    "display_name": "Pass or None",
+    "inputs": {
+      "any": {
+        "name": "anything"
+      }
+    },
+    "outputs": {
+      "0": {
+        "name": "output"
+      },
+      "1": {
+        "name": "is_none"
+      }
+    }
+  },
   "easy isNone": {
     "display_name": "Is None",
     "inputs": {

--- a/locales/zh/nodeDefs.json
+++ b/locales/zh/nodeDefs.json
@@ -6321,6 +6321,22 @@
       }
     }
   },
+  "easy PassOrNone": {
+    "display_name": "传递或为空",
+    "inputs": {
+      "any": {
+        "name": "任何"
+      }
+    },
+    "outputs": {
+      "0": {
+        "name": "输出"
+      },
+      "1": {
+        "name": "是否为空"
+      }
+    }
+  },
   "easy isNone": {
     "display_name": "是否为空",
     "inputs": {

--- a/py/nodes/logic.py
+++ b/py/nodes/logic.py
@@ -1000,13 +1000,44 @@ class isMaskEmpty(io.ComfyNode):
         return io.NodeOutput(False)
 
 
+class PassOrNone(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="easy PassOrNone",
+            description="Passes the input through, or outputs None when input is None/not provided.",
+            category="EasyUse/Logic",
+            search_aliases=[
+                "null",
+                "nothing",
+                "empty",
+                "blank",
+            ],
+            inputs=[
+                io.AnyType.Input("anything", tooltip="Passes the input through, or outputs None when no input is provided.", optional=True),
+            ],
+            outputs=[
+                io.AnyType.Output("output"),
+                io.Boolean.Output("is_none"),
+            ],
+        )
+
+    @classmethod
+    def execute(cls, anything=None):
+        return io.NodeOutput(
+            anything,
+            anything is None,
+        )
+
+
 class isNone(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
             node_id="easy isNone",
+            description="Returns true if the input is None, an empty string, or zero.",
             category="EasyUse/Logic",
-            inputs=[io.AnyType.Input("any")],
+            inputs=[io.AnyType.Input("any", tooltip="Returns true if the input is None, an empty string, or zero.")],
             outputs=[io.Boolean.Output("boolean")],
         )
 
@@ -1682,6 +1713,7 @@ NODE_CLASS_MAPPINGS = {
     "easy blocker": Blocker,
     "easy ifElse": IfElse,
     "easy isMaskEmpty": isMaskEmpty,
+    "easy PassOrNone": PassOrNone,
     "easy isNone": isNone,
     "easy isSDXL": isSDXL,
     "easy isFileExist": isFileExist,
@@ -1731,6 +1763,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "easy ifElse": "If else",
     "easy blocker": "Blocker",
     "easy isMaskEmpty": "Is Mask Empty",
+    "easy PassOrNone": "Pass or None",
     "easy isNone": "Is None",
     "easy isSDXL": "Is SDXL",
     "easy isFileExist": "Is File Exist",


### PR DESCRIPTION
I honestly wanted to rename the description of your existing **Is None** node to **Is Empty** because it is very misleading in what it does - it does not specifically check for `None`.

I've compromised by adding description and tooltip to that existing node.

-----

The existing **Is None** has limited usefulness, because virtually no nodes actually output `None`.

What would be **_extremely useful_** is instead a node that can output `None` when a connected node is bypassed / or nothing connected.

Taking it even further, including the boolean result as a separate output basically skips the next logical step that anyone would put after such a mechanism.

What I am proposing here essentially obsoletes the existing `Is None` node for the apparent intended purpose.  **Is None** SHOULD still exist under the label **Is Empty** and actually do what that says (check for `""`, `0`, etc).

---

[I had already pushed this node to my own repo.](https://github.com/altoiddealer/comfyui_essential-er#pass-or-none)

It's ridiculously useful.  It solves so many problems.

Screenshot from my repo

<img width="1530" height="620" alt="Screenshot 2026-09-06 203111" src="https://github.com/user-attachments/assets/4e7dacde-8547-45b8-aeaa-c57d974a3eab" />


# Please merge!